### PR TITLE
Update reputation tab 'sort button' handling

### DIFF
--- a/Reputation Investigation/src/ReputationInvestigation.ts
+++ b/Reputation Investigation/src/ReputationInvestigation.ts
@@ -115,11 +115,11 @@ $(() => {
         const tabSelectedRegex = /&sort=detailed/;
 
         function addUiItems() {
-            const detailedLink = $(`<a href="/users/${userId}?tab=reputation&amp;sort=detailed">detailed</a>`);
+            const detailedLink = $(`<a class="s-btn s-btn__muted s-btn__outlined s-btn__xs js-user-tab-sort" href="/users/${userId}?tab=reputation&amp;sort=detailed">Detailed</a>`);
 
             if (window.location.href.match(tabSelectedRegex)) {
-                $('.user-tab-sorts a').removeClass('youarehere');
-                $(detailedLink).addClass('youarehere');
+                $('.js-user-tab-sorts a').removeClass('is-selected');
+                $(detailedLink).addClass('is-selected');
 
                 $('#stats').prepend('<div id="rep-page-summary">');
 
@@ -155,7 +155,7 @@ $(() => {
                 setTimeout(() => { addUiItems(); });
             });
 
-            $('.user-tab-sorts').append(detailedLink);
+            $('.js-user-tab-sorts').append(detailedLink);
         }
         addUiItems();
 


### PR DESCRIPTION
The page got an overhaul and the tabs are now using different styling and classes. This update makes the link work again.