### PR TITLE
Use UTC in timestamps

### DIFF
--- a/Reputation Investigation/src/ReputationInvestigation.ts
+++ b/Reputation Investigation/src/ReputationInvestigation.ts
@@ -220,7 +220,7 @@ $(() => {
                     }
                     const htmlRow = $(`
                     <tr>
-                        <td>${moment.unix(event.creation_date).format('YYYY-MM-DD HH:mm:ss')}</td>
+                        <td>${moment.unix(event.creation_date).utc().format('YYYY-MM-DD HH:mm:ss')}</td>
                         <td>${event.reputation_history_type}</td>
                         <td id="rep-change" class="rep-change ${repChangeClass}">${event.reputation_change >= 0 ? '+' : ''}${event.reputation_change}</td>
                         <td class="post-col"><a href="/q/${event.post_id}">${event.title || (event.post_id + ' (deleted)')}</a><a class="post-matcher" href="javascript:void(0);">📌</a></td>


### PR DESCRIPTION
This matches every other timestamp display on Stack Overflow and makes it easier to line up data in this view with other information.

Tested locally (by direct edit of the installed userscript).

Fixes #3